### PR TITLE
Make sure that we dont use instance lock as it can cause deadlocks

### DIFF
--- a/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
+++ b/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
@@ -22,6 +22,11 @@ public class CloudwatchAppender extends AppenderSkeleton {
     private final Boolean DEBUG_MODE = System.getProperty("log4j.debug") != null;
 
     /**
+     * Used to make sure that on close() our daemon thread isn't also trying to sendMessage()s
+     */
+    private Object sendMessagesLock = new Object();
+
+    /**
      * The queue used to buffer log entries
      */
     private LinkedBlockingQueue<LoggingEvent> loggingEventsQueue;
@@ -92,47 +97,48 @@ public class CloudwatchAppender extends AppenderSkeleton {
         }
     }
 
-    private synchronized void sendMessages() {
-        LoggingEvent polledLoggingEvent;
+    private void sendMessages() {
+        synchronized(sendMessagesLock) {
+            LoggingEvent polledLoggingEvent;
 
-        List<LoggingEvent> loggingEvents = new ArrayList<>();
+            List<LoggingEvent> loggingEvents = new ArrayList<>();
 
-        try {
+            try {
 
-            while ((polledLoggingEvent = loggingEventsQueue.poll()) != null && loggingEvents.size() <= messagesBatchSize) {
-                loggingEvents.add(polledLoggingEvent);
-            }
+                while ((polledLoggingEvent = loggingEventsQueue.poll()) != null && loggingEvents.size() <= messagesBatchSize) {
+                    loggingEvents.add(polledLoggingEvent);
+                }
 
-            List<InputLogEvent> inputLogEvents = loggingEvents.stream()
-                    .map(loggingEvent -> new InputLogEvent().withTimestamp(loggingEvent.getTimeStamp()).withMessage(layout.format(loggingEvent)))
-                    .collect(toList());
+                List<InputLogEvent> inputLogEvents = loggingEvents.stream()
+                        .map(loggingEvent -> new InputLogEvent().withTimestamp(loggingEvent.getTimeStamp()).withMessage(layout.format(loggingEvent)))
+                        .collect(toList());
 
-            if (!inputLogEvents.isEmpty()) {
+                if (!inputLogEvents.isEmpty()) {
 
-                PutLogEventsRequest putLogEventsRequest = new PutLogEventsRequest(
-                        logGroupName,
-                        logStreamName,
-                        inputLogEvents);
+                    PutLogEventsRequest putLogEventsRequest = new PutLogEventsRequest(
+                            logGroupName,
+                            logStreamName,
+                            inputLogEvents);
 
-                try {
-                    putLogEventsRequest.setSequenceToken(lastSequenceToken.get());
-                    PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
-                    lastSequenceToken.set(result.getNextSequenceToken());
-                } catch (InvalidSequenceTokenException invalidSequenceTokenException) {
-                    putLogEventsRequest.setSequenceToken(invalidSequenceTokenException.getExpectedSequenceToken());
-                    PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
-                    lastSequenceToken.set(result.getNextSequenceToken());
-                    if (DEBUG_MODE) {
-                        invalidSequenceTokenException.printStackTrace();
+                    try {
+                        putLogEventsRequest.setSequenceToken(lastSequenceToken.get());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                    } catch (InvalidSequenceTokenException invalidSequenceTokenException) {
+                        putLogEventsRequest.setSequenceToken(invalidSequenceTokenException.getExpectedSequenceToken());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                        if (DEBUG_MODE) {
+                            invalidSequenceTokenException.printStackTrace();
+                        }
                     }
                 }
-            }
-        } catch (Exception e) {
-            if (DEBUG_MODE) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                if (DEBUG_MODE) {
+                    e.printStackTrace();
+                }
             }
         }
-
     }
 
     @Override


### PR DESCRIPTION
We recently ran into an instance where the CloudWatchAppender was causing a deadlock on our server. This is because RootLogger also uses the CloudWatchAppender instance lock when it appends messages so you can end up in the following scenario:

- [Thread1] Logs a message
- [CWADaemon] Locks on the CloudWatchAppender instance to send the message
- [Thread1] Logs another message. Inside of RootLogger, this grabs an internal Lock A, and then we also attempt to grab the CloudWatchAppender instance lock but can't because the daemon thread holds it
- [CWADaemon] The AWSClient internally attempts to LOG.info(...) a message (in our case it was because the message was too big). Inside of RootLogger, this attempts to grab Lock A, but it can't because Thread1 holds it.