### PR TITLE
Handle DataAlreadyAcceptedException

### DIFF
--- a/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
+++ b/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
@@ -125,6 +125,13 @@ public class CloudwatchAppender extends AppenderSkeleton {
                         putLogEventsRequest.setSequenceToken(lastSequenceToken.get());
                         PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
                         lastSequenceToken.set(result.getNextSequenceToken());
+                    } catch (DataAlreadyAcceptedException dataAlreadyAcceptedExcepted) {
+                    	putLogEventsRequest.setSequenceToken(dataAlreadyAcceptedExcepted.getExpectedSequenceToken());
+                        PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
+                        lastSequenceToken.set(result.getNextSequenceToken());
+                        if (DEBUG_MODE) {
+                        	dataAlreadyAcceptedExcepted.printStackTrace();
+                        }
                     } catch (InvalidSequenceTokenException invalidSequenceTokenException) {
                         putLogEventsRequest.setSequenceToken(invalidSequenceTokenException.getExpectedSequenceToken());
                         PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);

--- a/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
+++ b/src/main/java/com/github/speedwing/log4j/cloudwatch/appender/CloudwatchAppender.java
@@ -126,7 +126,7 @@ public class CloudwatchAppender extends AppenderSkeleton {
                         PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
                         lastSequenceToken.set(result.getNextSequenceToken());
                     } catch (DataAlreadyAcceptedException dataAlreadyAcceptedExcepted) {
-                    	putLogEventsRequest.setSequenceToken(dataAlreadyAcceptedExcepted.getExpectedSequenceToken());
+                        putLogEventsRequest.setSequenceToken(dataAlreadyAcceptedExcepted.getExpectedSequenceToken());
                         PutLogEventsResult result = awsLogsClient.putLogEvents(putLogEventsRequest);
                         lastSequenceToken.set(result.getNextSequenceToken());
                         if (DEBUG_MODE) {


### PR DESCRIPTION
Hey Gio,

We have also (very rarely) experienced the following exception:

`DataAlreadyAcceptedException: The given batch of log events has already been accepted. The next batch can be sent with sequenceToken: 49575434191296632061558566622677474456728342287823744514`

It looks like we can just re-submit it with the new sequence token on the exception similar to `InvalidSequenceTokenException`. Unfortunately, `DataAlreadyAcceptedException` and `InvalidSequenceTokenException` do not share a common class that has the `getExpectedSequenceToken()` method so I think we'll have to keep them in separate catch blocks for now.

Thanks much!